### PR TITLE
inlining operator that produces multiple symbols when linking against…

### DIFF
--- a/include/nil/marshalling/status_type.hpp
+++ b/include/nil/marshalling/status_type.hpp
@@ -51,7 +51,7 @@ namespace nil {
             error_status_amount    ///< Number of supported error statuses, must be last.
         };
 
-        status_type operator|(const status_type &l_status, const status_type &r_status) {
+        inline status_type operator|(const status_type &l_status, const status_type &r_status) {
             if (l_status == status_type::success) {
                 return r_status;
             }


### PR DESCRIPTION
… class library

This shows up when creating a class for an ECSDA key pair and then writing a test that uses that class.

This function will make the linker break with multiple symbols and so, I 'inlined' it.  I'm sure there are going to be others as I proceed.